### PR TITLE
Loosen CI Restrictions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,21 +28,17 @@ jobs:
         run: yarn deduplicate:check
 
   test:
-    name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}
+    name: Test on Node 12 using Ubuntu
 
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node: ['10.x', '12.x', '14.x']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Use Node ${{ matrix.node }}
+      - name: Use Node 12
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 12.x
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.json",
     "lint": "yarn build && yarn lint:post-build",
-    "lint:post-build": "node dist/index.js lint ./ --ignore-pattern 'test/e2e/fixtures/lint'",
+    "lint:post-build": "node dist/index.js lint $(git diff --name-only HEAD | grep -E \".js$|.ts$|.jsx$|.tsx$\" | xargs)",
     "test": "yarn build && yarn test:post-build",
     "test:post-build": "node dist/index.js test",
     "start": "tsc -p tsconfig.json --watch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ prog
       license = license.replace(/<year>/, `${new Date().getFullYear()}`)
 
       // attempt to automatically derive author name
-      let author = getAuthorName()
+      let author: string = getAuthorName()
 
       if (!author) {
         bootSpinner.stop()
@@ -571,11 +571,10 @@ prog
       _: string[]
     }) => {
       if (opts._.length === 0 && !opts['write-file']) {
-        const defaultInputs = [].filter(fs.existsSync)
-        opts._ = defaultInputs
+        opts._ = []
         console.log(
           chalk.yellow(
-            `Defaulting to "tsdx lint ${defaultInputs.join(' ')}"`,
+            `Defaulting to "tsdx lint"`,
             '\nYou can override this in the package.json scripts, like "lint": "tsdx lint src otherDir"'
           )
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,13 +62,13 @@ try {
   appPackageJson = fs.readJSONSync(paths.appPackageJson)
 } catch (e) {}
 
-export const isDir = (name: string) =>
+export const isDir = (name: string): Promise<boolean> =>
   fs
     .stat(name)
     .then((stats) => stats.isDirectory())
     .catch(() => false)
 
-export const isFile = (name: string) =>
+export const isFile = (name: string): Promise<boolean> =>
   fs
     .stat(name)
     .then((stats) => stats.isFile())
@@ -91,7 +91,7 @@ async function getInputs(
   source?: string
 ): Promise<string[]> {
   return concatAllArray(
-    ([] as any[])
+    ([] as unknown[])
       .concat(
         entries && entries.length
           ? entries
@@ -114,7 +114,7 @@ prog
     )}]`
   )
   .example('create --template react mypackage')
-  .action(async (pkg: string, opts: any) => {
+  .action(async (pkg: string, opts: Record<string, string>) => {
     console.log(
       chalk.blue(`
 ::::::::::: ::::::::  :::::::::  :::    :::
@@ -221,7 +221,7 @@ prog
       process.chdir(projectPath)
       const safeName = safePackageName(pkg)
       // eslint-disable-next-line sort-keys
-      const pkgJson = generatePackageJson({ name: safeName, author })
+      const pkgJson = generatePackageJson({ author, name: safeName })
 
       const nodeVersionReq = getNodeEngineRequirement(pkgJson)
       if (
@@ -406,7 +406,7 @@ prog
             await bundle.write(inputOptions.output)
           }
         )
-        .catch((e: any) => {
+        .catch((e: unknown) => {
           throw e
         })
         .then(async () => {
@@ -571,7 +571,7 @@ prog
       _: string[]
     }) => {
       if (opts._.length === 0 && !opts['write-file']) {
-        const defaultInputs = ['src', 'test'].filter(fs.existsSync)
+        const defaultInputs = [].filter(fs.existsSync)
         opts._ = defaultInputs
         console.log(
           chalk.yellow(

--- a/test/e2e/tsdx-lint.test.ts
+++ b/test/e2e/tsdx-lint.test.ts
@@ -1,113 +1,110 @@
-import * as shell from 'shelljs';
+import * as shell from 'shelljs'
 
-import * as util from '../utils/fixture';
+import * as util from '../utils/fixture'
 
-shell.config.silent = true;
+shell.config.silent = true
 
-const testDir = 'e2e';
-const stageName = 'stage-lint';
+const testDir = 'e2e'
+const stageName = 'stage-lint'
 
-const lintDir = `test/${testDir}/fixtures/lint`;
+const lintDir = `test/${testDir}/fixtures/lint`
 
 describe('tsdx lint', () => {
   it('should fail to lint a ts file with errors', () => {
-    const testFile = `${lintDir}/file-with-lint-errors.ts`;
-    const output = shell.exec(`node dist/index.js lint ${testFile}`);
-    expect(output.code).toBe(1);
-    expect(output.stdout.includes('Parsing error:')).toBe(true);
-  });
+    const testFile = `${lintDir}/file-with-lint-errors.ts`
+    const output = shell.exec(`node dist/index.js lint ${testFile}`)
+    expect(output.code).toBe(1)
+    expect(output.stdout.includes('Parsing error:')).toBe(true)
+  })
 
   it('should succeed linting a ts file without errors', () => {
-    const testFile = `${lintDir}/file-without-lint-error.ts`;
-    const output = shell.exec(`node dist/index.js lint ${testFile}`);
-    expect(output.code).toBe(0);
-  });
+    const testFile = `${lintDir}/file-without-lint-error.ts`
+    const output = shell.exec(`node dist/index.js lint ${testFile}`)
+    expect(output.code).toBe(0)
+  })
 
   it('should fail to lint a ts file with prettier errors', () => {
-    const testFile = `${lintDir}/file-with-prettier-lint-errors.ts`;
-    const output = shell.exec(`node dist/index.js lint ${testFile}`);
-    expect(output.code).toBe(1);
-    expect(output.stdout.includes('prettier/prettier')).toBe(true);
-  });
+    const testFile = `${lintDir}/file-with-prettier-lint-errors.ts`
+    const output = shell.exec(`node dist/index.js lint ${testFile}`)
+    expect(output.code).toBe(1)
+    expect(output.stdout.includes('prettier/prettier')).toBe(true)
+  })
 
   it('should fail to lint a tsx file with errors', () => {
-    const testFile = `${lintDir}/react-file-with-lint-errors.tsx`;
-    const output = shell.exec(`node dist/index.js lint ${testFile}`);
-    expect(output.code).toBe(1);
-    expect(output.stdout.includes('Parsing error:')).toBe(true);
-  });
+    const testFile = `${lintDir}/react-file-with-lint-errors.tsx`
+    const output = shell.exec(`node dist/index.js lint ${testFile}`)
+    expect(output.code).toBe(1)
+    expect(output.stdout.includes('Parsing error:')).toBe(true)
+  })
 
   it('should succeed linting a tsx file without errors', () => {
-    const testFile = `${lintDir}/react-file-without-lint-error.tsx`;
-    const output = shell.exec(`node dist/index.js lint ${testFile}`);
-    expect(output.code).toBe(0);
-  });
+    const testFile = `${lintDir}/react-file-without-lint-error.tsx`
+    const output = shell.exec(`node dist/index.js lint ${testFile}`)
+    expect(output.code).toBe(0)
+  })
 
   it('should succeed linting a ts file with warnings when --max-warnings is not used', () => {
-    const testFile = `${lintDir}/file-with-lint-warnings.ts`;
-    const output = shell.exec(`node dist/index.js lint ${testFile}`);
-    expect(output.code).toBe(0);
+    const testFile = `${lintDir}/file-with-lint-warnings.ts`
+    const output = shell.exec(`node dist/index.js lint ${testFile}`)
+    expect(output.code).toBe(0)
     expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
       true
-    );
-  });
+    )
+  })
 
   it('should succeed linting a ts file with fewer warnings than --max-warnings', () => {
-    const testFile = `${lintDir}/file-with-lint-warnings.ts`;
+    const testFile = `${lintDir}/file-with-lint-warnings.ts`
     const output = shell.exec(
       `node dist/index.js lint ${testFile} --max-warnings 4`
-    );
-    expect(output.code).toBe(0);
+    )
+    expect(output.code).toBe(0)
     expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
       true
-    );
-  });
+    )
+  })
 
   it('should succeed linting a ts file with same number of warnings as --max-warnings', () => {
-    const testFile = `${lintDir}/file-with-lint-warnings.ts`;
+    const testFile = `${lintDir}/file-with-lint-warnings.ts`
     const output = shell.exec(
       `node dist/index.js lint ${testFile} --max-warnings 3`
-    );
-    expect(output.code).toBe(0);
+    )
+    expect(output.code).toBe(0)
     expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
       true
-    );
-  });
+    )
+  })
 
   it('should fail to lint a ts file with more warnings than --max-warnings', () => {
-    const testFile = `${lintDir}/file-with-lint-warnings.ts`;
+    const testFile = `${lintDir}/file-with-lint-warnings.ts`
     const output = shell.exec(
       `node dist/index.js lint ${testFile} --max-warnings 2`
-    );
-    expect(output.code).toBe(1);
+    )
+    expect(output.code).toBe(1)
     expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
       true
-    );
-  });
+    )
+  })
 
   it('should not lint', () => {
-    const output = shell.exec(`node dist/index.js lint`);
-    expect(output.code).toBe(1);
-    expect(output.toString()).toContain('Defaulting to "tsdx lint src test"');
-    expect(output.toString()).toContain(
-      'You can override this in the package.json scripts, like "lint": "tsdx lint src otherDir"'
-    );
-  });
+    const output = shell.exec(`node dist/index.js lint`)
+    // Should do nothing
+    expect(output.code).toBe(0)
+  })
 
   describe('when --write-file is used', () => {
     beforeEach(() => {
-      util.teardownStage(stageName);
-      util.setupStageWithFixture(testDir, stageName, 'build-default');
-    });
+      util.teardownStage(stageName)
+      util.setupStageWithFixture(testDir, stageName, 'build-default')
+    })
 
     it('should create the file', () => {
-      const output = shell.exec(`node ../dist/index.js lint --write-file`);
-      expect(shell.test('-f', '.eslintrc.js')).toBeTruthy();
-      expect(output.code).toBe(0);
-    });
+      const output = shell.exec(`node ../dist/index.js lint --write-file`)
+      expect(shell.test('-f', '.eslintrc.js')).toBeTruthy()
+      expect(output.code).toBe(0)
+    })
 
     afterAll(() => {
-      util.teardownStage(stageName);
-    });
-  });
-});
+      util.teardownStage(stageName)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,12 +1431,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
-  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
-
-"@types/estree@0.0.39":
+"@types/estree@*", "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
@@ -1543,12 +1538,7 @@
   resolved "https://registry.yarnpkg.com/@types/mri/-/mri-1.1.1.tgz#bb2fb3f21068998e816fcdd2bcefd4233a711e6e"
   integrity sha512-nJOuiTlsvmClSr3+a/trTSx4DTuY/VURsWGKSf/eeavh0LRMqdsK60ti0TlwM5iHiGOK3/Ibkxsbr7i9rzGreA==
 
-"@types/node@*":
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.3.1.tgz#24691fa2b0c3ec8c0d34bfcfd495edac5593ebb4"
-  integrity sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==
-
-"@types/node@^14.11.1":
+"@types/node@*", "@types/node@^14.11.1":
   version "14.17.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.5.tgz#b59daf6a7ffa461b5648456ca59050ba8e40ed54"
   integrity sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==
@@ -1578,16 +1568,7 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
-"@types/react@*":
-  version "17.0.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
-  integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16.9.11":
+"@types/react@*", "@types/react@^16.9.11":
   version "16.14.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.11.tgz#992a0cd4b66b9f27315042b5d96e976717368f04"
   integrity sha512-Don0MtsZZ3fjwTJ2BsoqkyOy7e176KplEAKOpr/4XDdzinlyJBn9yfsKn5mcSgn4kh1B22+3tBnzBC1z63ybtQ==
@@ -4049,22 +4030,10 @@ glob-parent@^5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.1.4:
+glob@7.1.4, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -4474,15 +4443,10 @@ inherits@2, inherits@^2.0.0, inherits@^2.0.1, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@1.3.7:
+ini@1.3.7, ini@^1.3.4, ini@~1.3.0:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
   integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
-
-ini@^1.3.4, ini@~1.3.0:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
-  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inquirer-autosubmit-prompt@^0.2.0:
   version "0.2.0"
@@ -6004,15 +5968,10 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.2:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-ms@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multimatch@^4.0.0:
   version "4.0.0"
@@ -6991,7 +6950,7 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@6.0.1:
+postcss@6.0.1, postcss@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.1.tgz#000dbd1f8eef217aa368b9a212c5fc40b2a8f3f2"
   integrity sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=
@@ -6999,15 +6958,6 @@ postcss@6.0.1:
     chalk "^1.1.3"
     source-map "^0.5.6"
     supports-color "^3.2.3"
-
-postcss@^6.0.1:
-  version "6.0.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
-  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
-  dependencies:
-    chalk "^2.4.1"
-    source-map "^0.6.1"
-    supports-color "^5.4.0"
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.27, postcss@^7.0.32:
   version "7.0.36"
@@ -7617,12 +7567,7 @@ sade@^1.4.2:
   dependencies:
     mri "^1.1.0"
 
-safe-buffer@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==


### PR DESCRIPTION
To adjust TSDX for our needs, this PR removes CI runners that are not ubuntu. It also restricts linting to only lint changed files (to avoid re-linting the entire project based on our lint config) and updates tests based on these listing changes.